### PR TITLE
feat: search 컴포넌트 구현

### DIFF
--- a/src/components/common/search/Search.module.scss
+++ b/src/components/common/search/Search.module.scss
@@ -1,0 +1,71 @@
+.container {
+  padding: 3.2rem 2.4rem;
+  box-shadow: $search-popup-box-shadow;
+  border-radius: 1.6rem;
+  background-color: $white;
+
+  .text {
+    @include text-style(2, 700, $primary);
+    margin: 0 0 3.2rem 0;
+    line-height: 2.6rem;
+
+    @include responsive(M) {
+      @include text-style(1.6, 700, $primary);
+      margin: 0 0 1.5rem 0;
+    }
+  }
+
+  .wrap {
+    @include flexbox($flex-map);
+    position: relative;
+
+    .search-bar {
+      @include text-style(1.6, 400, $black);
+      width: 100%;
+      padding: 1.5rem 1.2rem 1.5rem 4.8rem;
+      border: 1px solid $gray70;
+      border-radius: 0.4rem;
+      line-height: 2.6rem;
+      background-color: $white;
+      background: url('~/public/icons/icon_bed.svg') no-repeat 1.2rem 1.6rem;
+
+      @include responsive(M) {
+        @include text-style(1.4, 400, $primary);
+        background: url('~/public/icons/icon_bed.svg') no-repeat 1.2rem 1.2rem;
+      }
+
+      &::placeholder {
+        @include text-style(1.6, 400, $gray50);
+        @include responsive(M) {
+          @include text-style(1.4, 400, $gray50);
+        }
+      }
+
+      &::-webkit-search-decoration,
+      &::-webkit-search-cancel-button,
+      &::-webkit-search-results-button,
+      &::-webkit-search-results-decoration {
+        display: none;
+      }
+    }
+
+    &.acitve {
+      &::before {
+        @include text-style(1.6, 400, $gray60);
+        content: '내가 원하는 체험은';
+        display: block;
+        position: absolute;
+        left: 4.3rem;
+        top: -1.2rem;
+        padding: 0 0.5rem;
+        line-height: 2.6rem;
+        background-color: $white;
+
+        @include responsive(M) {
+          @include text-style(1.5, 400, $gray60);
+          top: -1rem;
+        }
+      }
+    }
+  }
+}

--- a/src/components/common/search/Search.tsx
+++ b/src/components/common/search/Search.tsx
@@ -1,0 +1,54 @@
+import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
+import classNames from 'classnames/bind';
+import styles from './Search.module.scss';
+
+const cn = classNames.bind(styles);
+
+interface Activity {
+  title: string;
+}
+
+interface Props {
+  data: {
+    activities: Activity[];
+  };
+  setSearchResult: Dispatch<SetStateAction<Activity[]>>;
+}
+
+export default function Search({ data, setSearchResult }: Props) {
+  const [isKeyword, setIsKeyword] = useState<boolean>(false);
+  const [keyword, setKeyword] = useState<string>('');
+
+  const handleValueChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setKeyword(e.target.value);
+
+    if (e.target.value === '') {
+      setIsKeyword(false);
+    }
+  };
+
+  const handleSearchClick = () => {
+    if (!keyword) return;
+
+    const filterItem = data.activities.filter((activity: Activity) => activity.title.includes(keyword));
+    setSearchResult(filterItem);
+    setIsKeyword(true);
+  };
+
+  return (
+    <div className={cn('container')}>
+      <p className={cn('text')}>무엇을 체험하고 싶으신가요?</p>
+      <div className={cn('wrap', { acitve: isKeyword })}>
+        <input
+          className={cn('search-bar')}
+          type='search'
+          placeholder='내가 원하는 체험은'
+          onChange={handleValueChange}
+          value={keyword}
+        />
+        {/* TODO 버튼 컴포넌트 만들어지면 바꾸기 */}
+        <button onClick={handleSearchClick}>검색하기</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## ✒️ 주요 구현 사항

- #4 
- search 컴포넌트 구현

## 📷 스크린 샷
![recording (8)](https://github.com/Codeit-sprint2-4-5/global-nomad/assets/94034865/e350f17e-af84-44ad-950f-6164a724565e)

검색 결과 콘솔에 출력한 모습

![스크린샷 2024-03-03 183057](https://github.com/Codeit-sprint2-4-5/global-nomad/assets/94034865/747ccef1-2a0b-4b0a-9bf7-08459e9a349f)

## 📝 구체적 구현 사항 설명
- 검색 전과 검색 후 UI가 달라 active 클래스로 제어하였습니다
- title에 검색어가 포함되어 있으면 검색 결과가 나옵니다
- title에 검색어가 포함되어 있지 않으면 빈 배열이 나오고 검색어가 없으면 검색 기능이 동작되지 않도록 하였습니다
- data props으로 모든 체험이 들어있는 데이터를 넘겨줍니다
- searchResult state를 만들어서 setSearchResult를 props으로 넘겨주면 searchResult에 검색 결과가 담겨지고 이 state를 이용하여 검색 결과를 메인 페이지에 보여줄 수 있도록 만들 수 있습니다
- 버튼은 추후 버튼 컴포넌트가 머지되면 바꿀 예정입니다
- 검색을 할때 카테고리 or 가격 순 필터가 설정되어 있다면 모두 초기화 됩니다. 라고 기획서에 있는데 이 부분은 지금 카테고리 or 가격 순 필터가 없어서 완성이 되고나서 나중에 구현해야 할 것 같습니다

## 📢 논의 사항
![스크린샷 2024-03-04 190653](https://github.com/Codeit-sprint2-4-5/global-nomad/assets/94034865/54397124-fd32-436b-8568-bf9665b6d509)
![스크린샷 2024-03-04 190709](https://github.com/Codeit-sprint2-4-5/global-nomad/assets/94034865/61d4e220-9547-454a-8ef2-ec92763928be)
- 첫번째 이미지가 pc 버전이고 두번째가 tablet 버전인데 pc는 '내가 원하는 체험은' 양쪽 공간이 없고 태블릿은 오른쪽만 공간이 있는데 뭔가 저거를 따로 저렇게 나눠서 하는게 좀 별로인거 같고 굳이 저렇게 할 필요가 있을까 싶어서 일단은 '내가 원하는 체험은' 여기에 스크린샷처럼 조금만 공간을 줘서 했는데 여러분들 생각은 어떠신가요..?