### PR TITLE
feat: popup 컴포넌트 구현

### DIFF
--- a/src/components/common/popup/confirm/Confirm.module.scss
+++ b/src/components/common/popup/confirm/Confirm.module.scss
@@ -1,0 +1,48 @@
+.container {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 54rem;
+  height: 25rem;
+  border-radius: 0.8rem;
+  border: none;
+
+  &::backdrop {
+    opacity: 0.7;
+    background-color: $popup-background;
+  }
+
+  @media screen and (max-width: 550px) {
+    width: 100%;
+    height: 22rem;
+  }
+
+  .text {
+    @include text-style(1.8, 500, $primary);
+    position: absolute;
+    left: 50%;
+    top: calc(50% - 2.1rem);
+    transform: translateX(-50%);
+  }
+
+  .button {
+    button {
+      @include text-style(1.6, 500, $white);
+      position: absolute;
+      right: 2.8rem;
+      bottom: 2.8rem;
+      width: 12rem;
+
+      @media screen and (max-width: 550px) {
+        @include text-style(1.4, 500, $white);
+        position: absolute;
+        right: 50%;
+        bottom: 2.8rem;
+        transform: translateX(50%);
+        width: 13.8rem;
+        height: 4.2rem;
+      }
+    }
+  }
+}

--- a/src/components/common/popup/confirm/Confirm.tsx
+++ b/src/components/common/popup/confirm/Confirm.tsx
@@ -1,0 +1,29 @@
+import { RefObject } from 'react';
+import BaseButton from '@/components/common/button/BaseButton';
+import classNames from 'classnames/bind';
+import styles from './Confirm.module.scss';
+
+const cn = classNames.bind(styles);
+
+interface Props {
+  text: string;
+  dialogRef: RefObject<HTMLDialogElement>;
+}
+
+export default function Popup({ text, dialogRef }: Props) {
+  const handleCloseClick = () => {
+    if (!dialogRef.current) return;
+    dialogRef.current.close();
+  };
+
+  return (
+    <>
+      <dialog className={cn('container')} ref={dialogRef}>
+        <p className={cn('text')}>{text}</p>
+        <div className={cn('button')}>
+          <BaseButton onClick={handleCloseClick} size={'md'} text={'확인'} />
+        </div>
+      </dialog>
+    </>
+  );
+}

--- a/src/components/common/popup/question/Question.module.scss
+++ b/src/components/common/popup/question/Question.module.scss
@@ -1,0 +1,47 @@
+.container {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 29.8rem;
+  height: 18.4rem;
+  border-radius: 0.8rem;
+  border: none;
+  box-shadow: 0px 4px 16px 0px $search-popup-box-shadow;
+
+  &::before {
+    content: '';
+    display: block;
+    position: absolute;
+    left: 50%;
+    top: 2.4rem;
+    transform: translateX(-50%);
+    width: 2.4rem;
+    height: 2.4rem;
+    background: url('~/public/icons/Icon_popup_check.svg') no-repeat;
+  }
+
+  &::backdrop {
+    opacity: 0.7;
+    background-color: $popup-background;
+    transition: $base-transition;
+  }
+
+  .text {
+    @include text-style(1.6, 400, $primary);
+    padding: calc(50% - 8rem) 0 0;
+    font-family: 'Spoqa Han Sans Neo', sans-serif;
+    text-align: center;
+    line-height: 2.6rem;
+  }
+
+  .button-group {
+    @include flexbox(center, center);
+    gap: 0.8rem;
+    margin: 3.2rem 0 0;
+
+    button {
+      width: 8rem;
+    }
+  }
+}

--- a/src/components/common/popup/question/Question.tsx
+++ b/src/components/common/popup/question/Question.tsx
@@ -1,0 +1,49 @@
+import { RefObject } from 'react';
+import { instance } from '@/pages/api/axios';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import BaseButton from '@/components/common/button/BaseButton';
+import classNames from 'classnames/bind';
+import styles from './Question.module.scss';
+
+const cn = classNames.bind(styles);
+
+interface Props {
+  dialogRef: RefObject<HTMLDialogElement>;
+  reservationId: number;
+}
+
+export default function Question({ dialogRef, reservationId }: Props) {
+  async function patchReservation() {
+    await instance.patch(`/my-reservations/${reservationId}`, { status: 'canceled' });
+  }
+
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation({
+    mutationFn: patchReservation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/my-reservations'] });
+    },
+  });
+
+  const handleCancelClick = () => {
+    mutate();
+  };
+
+  const handleCloseClick = () => {
+    if (!dialogRef.current) return;
+    dialogRef.current.close();
+  };
+
+  return (
+    <>
+      <dialog className={cn('container')} ref={dialogRef}>
+        <p className={cn('text')}>예약을 취소하시겠어요?</p>
+        <div className={cn('button-group')}>
+          <BaseButton onClick={handleCloseClick} size={'sm'} variant={'outline'} text={'아니오'} />
+          <BaseButton onClick={handleCancelClick} size={'sm'} text={'취소하기'} />
+        </div>
+      </dialog>
+    </>
+  );
+}


### PR DESCRIPTION
## ✒️ 주요 구현 사항

- #26 
- popup 컴포넌트 구현

## 📷 스크린 샷

![recording (9)](https://github.com/Codeit-sprint2-4-5/global-nomad/assets/94034865/2868c9ec-d07e-4653-b4d8-9e862c20a7a4)
![recording (10)](https://github.com/Codeit-sprint2-4-5/global-nomad/assets/94034865/2a7eb5bd-47ef-4edc-bfbd-c89904cfa540)

## 📝 구체적 구현 사항 설명
- Confirm.tsx -> 확인 버튼이 있는 popup입니다
- Question.tsx -> 예/아니오 버튼이 있는 popup입니다
- dialog 태그를 이용하여 구현하였습니다
- 취소하기 버튼을 눌렀을 때 api는 연결했으나 예약 페이지가 만들어지지 않아 테스트는 진행하지 못했습니다 대략적으로 코드를 짰고 추후 테스트 진행 후 아마 수정사항이 생길 것 같아 수정 예정입니다
- refrash 토큰을 임시적으로 넣었고 추후 수정 예정입니다
- 버튼 컴포넌트 완성되면 바꿀 예정입니다

## 📢 논의 사항
