### PR TITLE
feat: 페이지네이션 구현

### DIFF
--- a/src/components/common/pagination/Pagination.module.scss
+++ b/src/components/common/pagination/Pagination.module.scss
@@ -1,0 +1,58 @@
+.container {
+  @include flexbox(center, center);
+  gap: 1rem;
+
+  button {
+    width: 5.5rem;
+    height: 5.5rem;
+    border: 1px solid $darkgreen;
+    border-radius: 1.5rem;
+    background-color: $white;
+
+    @include responsive(M) {
+      width: 4rem;
+      height: 4rem;
+    }
+  }
+
+  .control {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-indent: 100%;
+    background: url('~/public/icons/Icon_pagination_next.svg') no-repeat center $white;
+
+    &.prev {
+      transform: rotate(-180deg);
+
+      &:disabled {
+        border: 1px solid $gray30;
+        transform: rotate(0);
+        background: url('~/public/icons/Icon_pagination_prev.svg') no-repeat center $white;
+      }
+    }
+
+    &.next {
+      &:disabled {
+        border: 1px solid $gray30;
+        transform: rotate(-180deg);
+        background: url('~/public/icons/Icon_pagination_prev.svg') no-repeat center $white;
+      }
+    }
+  }
+
+  .page-number {
+    button {
+      @include text-style(1.8, 400, $darkgreen);
+
+      & + button {
+        margin: 0 0 0 1rem;
+      }
+
+      &.active {
+        color: $white;
+        background-color: $darkgreen;
+      }
+    }
+  }
+}

--- a/src/components/common/pagination/Pagination.tsx
+++ b/src/components/common/pagination/Pagination.tsx
@@ -1,0 +1,68 @@
+import { Dispatch, SetStateAction } from 'react';
+import classNames from 'classnames/bind';
+import styles from './Pagination.module.scss';
+
+const cn = classNames.bind(styles);
+
+interface Props {
+  data: {
+    totalCount: number;
+  };
+  currentPage: number;
+  setCurrentPage: Dispatch<SetStateAction<number>>;
+  PAGE_LIMIT: number;
+}
+
+export default function Pagination({ data, currentPage, setCurrentPage, PAGE_LIMIT }: Props) {
+  const BUTTON_LIMIT = 5;
+  const buttonGroup = Math.ceil(currentPage / BUTTON_LIMIT);
+  const totalPage = Math.ceil(data.totalCount / PAGE_LIMIT);
+  const START_PAGE = (buttonGroup - 1) * BUTTON_LIMIT + 1;
+
+  const handleButtonClick = (pageNumber: number) => {
+    setCurrentPage(pageNumber);
+  };
+
+  const handlePrevClick = () => {
+    setCurrentPage((old: number) => old - 1);
+  };
+
+  const handleNextClick = () => {
+    setCurrentPage((old: number) => old + 1);
+  };
+
+  return (
+    <div className={cn('container')}>
+      <button type='button' className={cn('control', 'prev')} onClick={handlePrevClick} disabled={currentPage === 1}>
+        이전
+      </button>
+      <div className={cn('page-number')}>
+        {Array(BUTTON_LIMIT)
+          .fill(START_PAGE)
+          .map((_, i) => {
+            const pageNumber = START_PAGE + i;
+            if (pageNumber > totalPage) return;
+
+            return (
+              <button
+                type='button'
+                key={i}
+                onClick={() => handleButtonClick(pageNumber)}
+                className={cn({ active: pageNumber === currentPage })}
+              >
+                {pageNumber}
+              </button>
+            );
+          })}
+      </div>
+      <button
+        type='button'
+        className={cn('control', 'next')}
+        onClick={handleNextClick}
+        disabled={currentPage === totalPage}
+      >
+        다음
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## ✒️ 주요 구현 사항

- #31 
- 페이지네이션 기능 구현

## 📷 스크린 샷
![recording (13)](https://github.com/Codeit-sprint2-4-5/global-nomad/assets/94034865/ebb509e3-8505-487e-9a19-966b206cea82)

## 📝 구체적 구현 사항 설명
- 원래 피그마에서는 메인에서 8개, 체험 상세페이지에서 3개씩 데이터 보여주는건데 지금 데이터 수가 적어 일단 1개씩 보여주는 걸로 테스트하였습니다
- 페이지 번호와 이전 다음 버튼을 눌렀을 때 모두 해당하는 데이터를 불러와 보여줍니다
- 첫 페이지와 마지막 페이지는 버튼이 비활성화 됩니다
- 데이터 개수만큼 페이지 번호가 보여집니다

## 📢 논의 사항
