### PR TITLE
design: layout 추가

### DIFF
--- a/src/components/common/layout/Layout.module.scss
+++ b/src/components/common/layout/Layout.module.scss
@@ -1,0 +1,13 @@
+.main {
+  max-width: 120rem;
+  margin: 0 auto;
+  padding: 7rem 0 16rem 0;
+
+  @include responsive(T) {
+    padding: 7rem 2.4rem 16rem 2.4rem;
+  }
+
+  @include responsive(M) {
+    padding: 7rem 1.6rem 16rem 1.6rem;
+  }
+}

--- a/src/components/common/layout/Layout.tsx
+++ b/src/components/common/layout/Layout.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+import Footer from '@/components/common/footer/Footer';
+import classNames from 'classnames/bind';
+import styles from './Layout.module.scss';
+
+const cn = classNames.bind(styles);
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      {/* TODO gnb 컴포넌트 만들어지면 import해서 넣기 */}
+      <main className={cn('main')}>{children}</main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## ✒️ 주요 구현 사항

- #44 
- 전체 페이지 레이아웃 구현

## 📷 스크린 샷

헤더와 푸터는 고정적이고 메인에 들어갈 컴포넌트만 넘겨준 모습입니다
![localhost_3000_ (12)](https://github.com/Codeit-sprint2-4-5/global-nomad/assets/94034865/f09375d8-d179-42ad-8f83-e7eaabd3fcf9)

## 📝 구체적 구현 사항 설명
- 로그인, 회원가입 페이지를 제외하고 나머지 페이지에서 공통으로 사용할 수 있는 레이아웃이며 반응형까지 구현하였습니다
- main 태그 안에 들어갈 컴포넌트들을 children으로 받아 보여줍니다
- gnb 컴포넌트가 완성되면 헤더에 넣을 예정입니다 

## 📢 논의 사항
