### PR TITLE
feat: 예약현황 - 달력 컴포넌트 구현

### DIFF
--- a/src/components/calendar/Calendar.module.scss
+++ b/src/components/calendar/Calendar.module.scss
@@ -1,0 +1,76 @@
+.date-control {
+  @include text-style(2, 700, $black);
+  @include flexbox(between, center);
+  width: 34.2rem;
+  margin: 0 auto 2.9rem;
+  line-height: 2.6rem;
+
+  .button {
+    overflow: hidden;
+    white-space: nowrap;
+    text-indent: 100%;
+    width: 2.4rem;
+    height: 2.4rem;
+    background: url('~/public/icons/Icon_calendar_control.svg') no-repeat;
+
+    &.next {
+      transform: rotate(-180deg);
+    }
+  }
+
+  .date {
+    @include flexbox(center, center);
+    gap: 0.5rem;
+  }
+}
+
+.calendar {
+  overflow: hidden;
+  width: 80rem;
+  margin: 0 auto;
+  border-radius: 0.8rem;
+  border: 1px solid $calendar-border;
+
+  @include responsive(M) {
+    width: 100%;
+  }
+
+  .table {
+    width: 80rem;
+    border-collapse: collapse;
+
+    @include responsive(M) {
+      width: 100%;
+    }
+
+    th,
+    td {
+      text-align: left;
+      padding: 1.2rem;
+      font-family: 'Inter', sans-serif;
+      border-right: 1px solid $calendar-border;
+      border-top: 1px solid $calendar-border;
+      background-color: $white;
+
+      &:last-child {
+        border-right: none;
+      }
+    }
+
+    th {
+      @include text-style(1.6, 500, $calendar-text-color);
+      border-top: none;
+    }
+
+    td {
+      @include text-style(2.1, 500, $calendar-text-color);
+      height: 15.4rem;
+      vertical-align: top;
+      cursor: pointer;
+
+      &.active {
+        color: $calendar-text-active-color;
+      }
+    }
+  }
+}

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import classNames from 'classnames/bind';
+import styles from './Calendar.module.scss';
+
+const cn = classNames.bind(styles);
+
+export default function Calendar() {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const dayArr = ['SUN', 'MON', 'TUE', 'WED', 'THUR', 'FRI', 'SAT'];
+
+  const currentYear = currentDate.getFullYear();
+  const currentMonth = currentDate.getMonth();
+  const prevMonthStartDay = new Date(currentYear, currentMonth, 1).getDay();
+  const prevMonthEndDate = new Date(currentYear, currentMonth, 0).getDate();
+  const currentMonthDay = new Date(currentYear, currentMonth + 1, 0);
+  const remainingDate = 6 - currentMonthDay.getDay();
+  const dateRow = currentMonthDay.getDay() === 0 ? 6 : 5;
+
+  const prevMonthDate = Array.from(
+    { length: prevMonthStartDay },
+    (_, i) => prevMonthEndDate - prevMonthStartDay + i + 1
+  );
+  const currentMonthDate = Array.from({ length: currentMonthDay.getDate() }, (_, i) => i + 1);
+  const nextMonthDate = Array.from({ length: remainingDate }, (_, i) => i + 1);
+  const days = [...prevMonthDate, ...currentMonthDate, ...nextMonthDate];
+  
+  const handlePrevClick = () => {
+    setCurrentDate(new Date(currentYear, currentMonth - 1));
+  };
+
+  const handleNextClick = () => {
+    setCurrentDate(new Date(currentYear, currentMonth + 1));
+  };
+
+  return (
+    <>
+      <div className={cn('date-control')}>
+        <button type='button' className={cn('button', 'prev')} onClick={handlePrevClick}>
+          이전
+        </button>
+        <div className={cn('date')}>
+          <p className={cn('year')}>{currentYear}년</p>
+          <p className={cn('month')}>{currentMonth + 1}월</p>
+        </div>
+        <button type='button' className={cn('button', 'next')} onClick={handleNextClick}>
+          다음
+        </button>
+      </div>
+      <div className={cn('calendar')}>
+        <table className={cn('table')}>
+          <colgroup>
+            <col style={{ width: '14.2%' }} />
+            <col style={{ width: '14.2%' }} />
+            <col style={{ width: '14.2%' }} />
+            <col style={{ width: '14.2%' }} />
+            <col style={{ width: '14.2%' }} />
+            <col style={{ width: '14.2%' }} />
+            <col style={{ width: '14.2%' }} />
+          </colgroup>
+          <thead>
+            <tr>
+              {dayArr.map((day, i) => (
+                <th key={i}>{day}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {Array(dateRow)
+              .fill(null)
+              .map((_, dayIdx) => (
+                <tr key={dayIdx}>
+                  {Array(7)
+                    .fill(null)
+                    .map((_, i) => {
+                      const currentMonthDate = dayIdx * 7 + i;
+                      const remainingDate =
+                        currentMonthDate < prevMonthDate.length ||
+                        currentMonthDate > prevMonthDate.length + currentMonthDay.getDate() - 1;
+
+                      return (
+                        <td key={i} className={cn({ active: remainingDate })}>
+                          {days[currentMonthDate]}
+                        </td>
+                      );
+                    })}
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## ✒️ 주요 구현 사항

- [x] 예약현황 페이지에 들어가는 달력을 컴포넌트로 만들었습니다

## 📷 스크린 샷
![recording (15)](https://github.com/Codeit-sprint2-4-5/global-nomad/assets/94034865/03c6207f-0d27-4924-bd7a-165b863e929b)


## 📝 구체적 구현 사항 설명

- 라이브러리를 사용할까 하다가 공부해보려고 직접 만들었습니다
- 이전 달의 날짜와 다음 달의 날짜가 나오게 만들었습니다

## 📢 논의 사항
- 피그마에서는 이번 달의 날짜만 나오게 되어있는거 같은데 제가 달력의 완성도를 조금 더 높이고 싶어서 이전 달의 날짜와 다음 달의 날짜를 보여지게 했고 색상도 좀 연하게 해봤는데 여러분들 생각은 어떤가요?