### PR TITLE
feat: 체험상세 - 체험 상세 정보, 케밥 구현

### DIFF
--- a/src/components/domain/activityInfo/ActivityInfo.module.scss
+++ b/src/components/domain/activityInfo/ActivityInfo.module.scss
@@ -1,0 +1,26 @@
+.container {
+  @include flexbox(between, center);
+  @include text-style(1.4, 400, $gray90);
+
+  .category {
+    overflow: hidden;
+    margin: 0 0 1rem 0;
+  }
+
+  .wrap {
+    @include flexbox(left, center);
+    gap: 1.2rem;
+    margin: 2.2rem 0 0;
+  }
+
+  .rating {
+    padding: 0 0 0 2.2rem;
+    @include text-style(1.4, 400, $black);
+    background: url('~/public/icons/Icon_star.svg') no-repeat;
+  }
+
+  .address {
+    padding: 0 0 0 1.8rem;
+    background: url('~/public/icons/Icon_location.png') no-repeat;
+  }
+}

--- a/src/components/domain/activityInfo/ActivityInfo.tsx
+++ b/src/components/domain/activityInfo/ActivityInfo.tsx
@@ -1,0 +1,105 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { useRef } from 'react';
+import { instance } from '@/apis/axios';
+import Title from '@/components/common/title/Title';
+import Menu from '@/components/common/menu/Menu';
+import Question from '@/components/common/popup/question/Question';
+import Confirm from '@/components/common/popup/confirm/Confirm';
+import classNames from 'classnames/bind';
+import styles from './ActivityInfo.module.scss';
+
+const cn = classNames.bind(styles);
+
+export default function ActivityInfo() {
+  const router = useRouter();
+  const { id } = router.query;
+  const queryClient = useQueryClient();
+  const confirmRef = useRef<HTMLDialogElement>(null);
+  const questionRef = useRef<HTMLDialogElement>(null);
+
+  async function getAcitivity() {
+    try {
+      const res = await instance.get(`/activities/${id}`);
+      return res.data;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  async function getUser() {
+    try {
+      const res = await instance.get('/users/me');
+      return res.data;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  async function deleteActivity() {
+    try {
+      const res = await instance.delete(`/my-activities/${id}`);
+      return res.data;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  const { data: activity } = useQuery({
+    queryKey: ['/activities'],
+    queryFn: getAcitivity,
+  });
+
+  const { data: user } = useQuery({
+    queryKey: ['/users/me'],
+    queryFn: getUser,
+  });
+
+  const { mutate } = useMutation({
+    mutationKey: ['/my-activities'],
+    mutationFn: deleteActivity,
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/my-activities'] });
+      handleSuccess();
+    },
+  });
+
+  const handleModifyClick = () => {
+    router.push('/editActivity');
+  };
+
+  const handleDeleteClick = () => {
+    if (!questionRef.current) return;
+    questionRef.current.showModal();
+  };
+
+  const handleButtonClick = () => {
+    mutate();
+  };
+
+  const handleSuccess = () => {
+    if (!confirmRef.current) return;
+    confirmRef.current.showModal();
+  };
+
+  return (
+    <>
+      <div className={cn('container')}>
+        <div className={cn('activity-info')}>
+          <p className={cn('category')}>{activity?.category}</p>
+          <Title text={activity?.title} />
+          <div className={cn('wrap')}>
+            <p className={cn('rating')}>{activity?.rating}</p>
+            <p className={cn('address')}>{activity?.address}</p>
+          </div>
+        </div>
+        {activity?.userId === user?.id && (
+          <Menu handleModifyClick={handleModifyClick} handleDeleteClick={handleDeleteClick} />
+        )}
+      </div>
+      <Question text='삭제하시겠습니까?' dialogRef={questionRef} buttonText='삭제하기' onClick={handleButtonClick} />
+      <Confirm text='삭제되었습니다' dialogRef={confirmRef} />
+    </>
+  );
+}


### PR DESCRIPTION
## ✒️ 주요 구현 사항

- [x] 체험 상세 정보, 케밥 구현

## 📷 스크린 샷
![recording (19)](https://github.com/Codeit-sprint2-4-5/global-nomad/assets/94034865/9a68a03f-f7f4-45cd-8515-d1944df60372)

## 📝 구체적 구현 사항 설명
- id값을 받아와 체험 상세 정보를 보여줍니다
- 내가 등록한 체험일 경우 케밥을 보여주고 아닐경우 케밥을 보여주지 않습니다
- 케밥의 수정을 누르면 내 체험 수정페이지로 이동하고 삭제를 누르면 체험을 삭제합니다

## 📢 논의 사항
